### PR TITLE
Downgrade @types/vscode

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -293,9 +293,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.44.0.tgz",
-      "integrity": "sha512-WJZtZlinE3meRdH+I7wTsIhpz/GLhqEQwmPGeh4s1irWLwMzCeTV8WZ+pgPTwrDXoafVUWwo1LiZ9HJVHFlJSQ==",
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
+      "integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
       "dev": true
     },
     "add-variable-declarations": {

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.13.0",
     "@types/prettier": "^1.19.0",
-    "@types/vscode": "^1.44.0",
+    "@types/vscode": "^1.33.0",
     "chai": "^4.2.0",
     "mocha": "^7.1.1",
     "prettier": "1.19.1",


### PR DESCRIPTION
Downgrade @types/vscode to 1.33.0 since we're still supporting that vscode API.