### PR TITLE
Add the "Fix Expected Comma" codefix to list of refactors

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,5 +7,7 @@
     "out": true // set this to false to include "out" folder in search results
   },
   // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-  "typescript.tsc.autoDetect": "off"
+  "typescript.tsc.autoDetect": "off",
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "javascript.validate.enable": false
 }

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ toTypeScript provides the following configurations representing TypeScript [Quic
 | `toTypeScript.addMissingMember` | Declare missing class members - default: `true`|
 | `toTypeScript.forgottenThisPropertyAccess` | Add `this.` to unresolved variables - default: `true`  |
 | `toTypeScript.fixAwaitInSyncFunction` | Add `async` modifier to containing functions using `await` - default: `true`  |
+| `toTypeScript.fixExpectedComma` | Replace `;` to `,` within a list. - default: `true`  |
 | `toTypeScript.requireInTs` | Convert `require` to `import` - default: `true`  |
 | `toTypeScript.fixUnreachableCode` | Remove unreachable code - default: `true`  |
 | `toTypeScript.fixUnusedLabel` | Remove unused labels - default: `true`  |

--- a/package.json
+++ b/package.json
@@ -69,6 +69,11 @@
           "default": true,
           "description": ""
         },
+        "toTypeScript.fixExpectedComma": {
+          "type": "boolean",
+          "default": true,
+          "description": ""
+        },
         "toTypeScript.fixUnreachableCode": {
           "type": "boolean",
           "default": true,

--- a/src/configUtils.ts
+++ b/src/configUtils.ts
@@ -9,6 +9,7 @@ const tsFixIds = [
   "fixUnreachableCode",
   "fixUnusedLabel",
   "fixAwaitInSyncFunction",
+  "fixExpectedComma",
   "requireInTs",
 ];
 

--- a/src/test/e2e/code-fixes/fixExpectedComma.test.ts
+++ b/src/test/e2e/code-fixes/fixExpectedComma.test.ts
@@ -1,0 +1,24 @@
+import { expect } from 'chai';
+import { commands, window, TextEditor } from "vscode";
+import * as path from "path";
+import { unlinkSync } from "fs";
+import { openEditorForTestFile, testFolderPath, normalizeTextFormat } from "../../support";
+
+describe("fixExpectedComma", function () {
+  const tsFileName = "fixExpectedComma.ts";
+  const jsFileName = "fixExpectedComma.js";
+
+  afterEach(function() {
+    unlinkSync(path.join(testFolderPath + tsFileName));
+  });
+
+  it("applies fixExpectedComma code fix to converted file", async function() {
+    await openEditorForTestFile(jsFileName);
+    await commands.executeCommand("extension.toTypeScript");
+    const currentEditor = window.activeTextEditor as TextEditor;
+    const convertedContent = `const example = { a: "one", c: "two" };\n`;
+    const actualContent = normalizeTextFormat(currentEditor.document.getText());
+    expect(currentEditor.document.fileName).to.equal(path.join(testFolderPath + tsFileName));
+    expect(actualContent).to.equal(convertedContent);
+  });
+});

--- a/src/test/e2e/examples/fixExpectedComma.js
+++ b/src/test/e2e/examples/fixExpectedComma.js
@@ -1,0 +1,1 @@
+const example = { a : "one"; c : "two"};

--- a/src/test/unit/configUtils.test.ts
+++ b/src/test/unit/configUtils.test.ts
@@ -11,6 +11,7 @@ describe("buildTSFixIds", function () {
       "fixUnreachableCode",
       "fixUnusedLabel",
       "fixAwaitInSyncFunction",
+      "fixExpectedComma",
       "requireInTs",
     ];
 


### PR DESCRIPTION
This adds the "Fix Expected Comma" codefix to the list of codefixes that to-typescript will run on newly created ts files.

The "Fix Expected Comma" replaces semicolons with commas where a comma should be used.