### PR TITLE
Update minimum vscode compatible version.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -293,9 +293,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.33.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.33.0.tgz",
-      "integrity": "sha512-JSmGiValbrcG5g20jjCfKakLiuWyrcjVezj+SEAEZ4klXQktE5EtowuGlkLVqbkiBK4iY5wy/4yW8OjecuHnjQ==",
+      "version": "1.47.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
+      "integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
       "dev": true
     },
     "add-variable-declarations": {

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "@types/mocha": "^7.0.2",
     "@types/node": "^13.13.0",
     "@types/prettier": "^2.0.1",
-    "@types/vscode": "^1.33.0",
+    "@types/vscode": "^1.47.0",
     "chai": "^4.2.0",
     "mocha": "^7.1.1",
     "prettier": "1.19.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "version": "0.1.2",
   "license": "MIT",
   "engines": {
-    "vscode": "^1.33.0"
+    "vscode": "^1.47.0"
   },
   "icon": "images/icon.png",
   "homepage": "https://github.com/alecclarke/to-typescript",


### PR DESCRIPTION
Updating the mimum vscode version that can be used for newer versions of the extension. This will prevent some issues that happen when the extension is running on older versions of vscode/typescript.