### PR TITLE
Add all relevant decaffeinate flags as config options

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,86 @@
           "type": "boolean",
           "default": true,
           "description": ""
+        },
+        "toTypeScript.coffeescript.useCS2": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.literate": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.disableSuggestionComment": {
+          "type": ["boolean", "null"],
+          "default": true,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.noArrayIncludes": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.useJSModules": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.looseJSModules": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.safeImportFunctionIdentifiers": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.preferLet": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.loose": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.looseDefaultParams": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.looseForExpressions": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.looseForOf": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.looseIncludes": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.looseComparisonNegation": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.disallowInvalidConstructors": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
+        },
+        "toTypeScript.coffeescript.optionalChaining": {
+          "type": ["boolean", "null"],
+          "default": null,
+          "description": ""
         }
       }
     }

--- a/src/adapters/coffeeScriptAdapter.ts
+++ b/src/adapters/coffeeScriptAdapter.ts
@@ -1,6 +1,7 @@
 import { convert } from 'decaffeinate';
 import { TextDocument } from 'vscode';
 import { TSAdapter } from './tsAdapterInterface';
+import { getCoffeescriptConfig } from '../configUtils';
 
 export class CoffeeScriptAdapter implements TSAdapter {
   private document: TextDocument;
@@ -11,7 +12,7 @@ export class CoffeeScriptAdapter implements TSAdapter {
 
   public getFileContent(): string {
     const coffeeScriptContent = this.document.getText();
-    const options = { disableSuggestionComment: true };
+    const options = getCoffeescriptConfig();
     return convert(coffeeScriptContent, options).code;
   }
 

--- a/src/configUtils.ts
+++ b/src/configUtils.ts
@@ -21,8 +21,16 @@ export function buildTSFixIds(): string[] {
 
 export function getEditorConfig(configUri: Uri): FormatCodeSettings {
   const indentSize = workspace.getConfiguration("editor", configUri).get("tabSize", 2);
-  
+
   return {
     indentSize,
   };
+}
+
+export function getCoffeescriptConfig() {
+  const config = workspace.getConfiguration("toTypeScript.coffeescript");
+  return Object.keys(config).reduce((result, key) => {
+    const value = config.get(key);
+    return typeof value === 'boolean' ? { ...result, [key]: value } : result;
+  }, {});
 }

--- a/src/test/unit/configUtils.test.ts
+++ b/src/test/unit/configUtils.test.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { buildTSFixIds } from '../../configUtils';
+import { buildTSFixIds, getCoffeescriptConfig } from '../../configUtils';
 
 describe("buildTSFixIds", function () {
   it("returns the fixIds defined in the settings", function() {
@@ -16,5 +16,12 @@ describe("buildTSFixIds", function () {
     ];
 
     expect(defaultFixIds).to.eql(buildTSFixIds());
+  });
+});
+
+describe("getCoffeescriptConfig", function () {
+  it("returns the default coffeescript config", async function() {
+    const expected = {disableSuggestionComment: true};
+    expect(expected).to.eql(getCoffeescriptConfig());
   });
 });


### PR DESCRIPTION
This doesn't change the current behavior of the extension, and only affects the coffeescript adapter.

- `disableSuggestionComment` still defaults to `true`
- All other options default to `null` and thus will use decaffeinate's defaults